### PR TITLE
expand playarea for scroll bar

### DIFF
--- a/css/myrmex.css
+++ b/css/myrmex.css
@@ -33,7 +33,7 @@ body {
 
 #playarea {
     padding: 125px 10px 10px 10px;
-    width: 1122px;
+    width: 1137px;
     margin: 0 auto;
     height: 100%;
     overflow: auto;


### PR DESCRIPTION
Fixes #1.

When a card sticks off the bottom of the play area (because a run of two or more cards is dragged near the bottom, or because a pile has grown very tall, or because the window is resized to be short), a vertical scroll bar appears on the play area. On a Mac this poses no problem, but on Windows (and presumably on some other systems) this scroll bar takes up some horizontal space, causing the play area to reflow and one of the piles to head south for the winter.

We can avoid this reflow by reserving 15px of extra space to put the scroll bar in. I've chosen to add this space unconditionally, on the grounds that I don't want to pull in a fancy platform-inference module, 15px of extra space will hardly ever be noticeable, and if it does overflow a window then you just get a (much safer) horizontal scroll.

As to the size, 15px is a guess based on some casual Internet searching, and works for me on my Windows machine.